### PR TITLE
Update default launch template version

### DIFF
--- a/modules/aws_auto_scale/main.tf
+++ b/modules/aws_auto_scale/main.tf
@@ -89,6 +89,7 @@ resource "aws_launch_template" "aws_autoscale_templ" {
   }
   tags                        = var.tags
   user_data                   = var.userData
+  update_default_version      = true
 }
 
 resource "aws_autoscaling_group" "mygroup" {
@@ -101,5 +102,4 @@ resource "aws_autoscaling_group" "mygroup" {
   min_size                  = 1
   name                      = "WebServerASG"
   termination_policies      = ["OldestInstance"]
-  update_default_version    = true
 }

--- a/modules/aws_auto_scale/main.tf
+++ b/modules/aws_auto_scale/main.tf
@@ -101,4 +101,5 @@ resource "aws_autoscaling_group" "mygroup" {
   min_size                  = 1
   name                      = "WebServerASG"
   termination_policies      = ["OldestInstance"]
+  update_default_version    = true
 }


### PR DESCRIPTION
The current terraform module creates a launch template but doesn't automatically update the default version on deployment. This change resolves that.